### PR TITLE
Remove reloadData from setFrame

### DIFF
--- a/YKPagedScrollView/YKPagedScrollView.m
+++ b/YKPagedScrollView/YKPagedScrollView.m
@@ -55,7 +55,6 @@
 - (void)setFrame:(CGRect)frame {
     [super setFrame:frame];
     _scrollView.frame = [self rectForPage];
-    [self reloadData];
 }
 
 - (void)layoutSubviews {


### PR DESCRIPTION
Relading Data on setFrame will initialize the scroll view and the page returns to the first page unintentionally. Removing reloadData from setFrame function will maintain the current page.
